### PR TITLE
Update version numbers and enhance currency formatting

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,9 @@
       "Bash(sudo lsof:*)",
       "Bash(lsof:*)",
       "Bash(chmod:*)",
-      "Bash(git:*)"
+      "Bash(git:*)",
+      "Bash(pnpm --filter @price-monitor/web test --run)",
+      "Bash(pnpm --filter @price-monitor/worker test --run)"
     ]
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@price-monitor/web",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "scripts": {
     "dev": "concurrently -n next,tsc -c cyan,yellow \"next dev\" \"tsc --watch --noEmit --preserveWatchOutput\"",

--- a/apps/web/src/app/(main)/dashboard/products/_components/product-card-view.tsx
+++ b/apps/web/src/app/(main)/dashboard/products/_components/product-card-view.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { formatPrice } from "@/lib/format";
 
 import { DeleteProductDialog } from "./delete-product-dialog";
 import { EditProductDialog } from "./edit-product-dialog";
@@ -32,13 +33,6 @@ export function ProductCardView({ products }: ProductCardViewProps) {
   const [deletingProduct, setDeletingProduct] = useState<ProductWithStats | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { handleCheckPrice, checkingPriceId } = useCheckPrice();
-
-  const formatPrice = (cents: number, currency: string) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: currency,
-    }).format(cents / 100);
-  };
 
   const calculatePriceChange = (history: Array<{ date: Date; price: number }>) => {
     if (history.length < 2) return null;

--- a/apps/web/src/app/(main)/dashboard/products/_components/product-table-view.tsx
+++ b/apps/web/src/app/(main)/dashboard/products/_components/product-table-view.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { formatPrice } from "@/lib/format";
 
 import { DeleteProductDialog } from "./delete-product-dialog";
 import { EditProductDialog } from "./edit-product-dialog";
@@ -35,13 +36,6 @@ export function ProductTableView({ products }: ProductTableViewProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [sorting, setSorting] = useState<SortingState>([]);
   const { handleCheckPrice, checkingPriceId } = useCheckPrice();
-
-  const formatPrice = (cents: number, currency: string) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: currency,
-    }).format(cents / 100);
-  };
 
   const columns: ColumnDef<ProductWithStats>[] = [
     {

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -28,4 +28,16 @@ describe("formatPrice", () => {
     expect(formatPrice(-500, "USD")).toContain("5.00");
     expect(formatPrice(-500, "USD").startsWith("-")).toBe(true);
   });
+
+  it("falls back to a plain string when the currency is not a valid ISO 4217 code", () => {
+    // Regression: a row with currency "$" (literal symbol) crashed SSR with
+    // RangeError and took down the dashboard. Formatter must not throw.
+    expect(formatPrice(1999, "$")).toBe("$ 19.99");
+    expect(formatPrice(1999, "not-a-code")).toBe("not-a-code 19.99");
+  });
+
+  it("treats null / undefined currency as the default rather than crashing", () => {
+    expect(formatPrice(1999, null)).toBe("A$19.99");
+    expect(formatPrice(1999, undefined)).toBe("A$19.99");
+  });
 });

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,6 +1,15 @@
-export function formatPrice(cents: number, currency = "AUD") {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-  }).format(cents / 100);
+export function formatPrice(cents: number, currency: string | null | undefined = "AUD") {
+  const amount = cents / 100;
+  const code = currency ?? "AUD";
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: code,
+    }).format(amount);
+  } catch {
+    // Intl.NumberFormat throws RangeError for non-ISO 4217 codes (e.g. "$"
+    // accidentally stored by the scraper). Degrade to a plain string instead
+    // of crashing the page.
+    return `${code} ${amount.toFixed(2)}`;
+  }
 }

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -56,4 +56,10 @@ describe("formatCurrency", () => {
   it("forwards explicit min/maxFractionDigits when noDecimals is unset", () => {
     expect(formatCurrency(1, { minimumFractionDigits: 4, maximumFractionDigits: 4 })).toBe("$1.0000");
   });
+
+  it("falls back to a plain string when the currency is not valid ISO 4217", () => {
+    // Regression: passing "$" to Intl.NumberFormat throws RangeError and crashes SSR.
+    expect(formatCurrency(19.99, { currency: "$" })).toBe("$ 19.99");
+    expect(formatCurrency(1234.56, { currency: "bogus", noDecimals: true })).toBe("bogus 1235");
+  });
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -38,5 +38,12 @@ export function formatCurrency(
     maximumFractionDigits: noDecimals ? 0 : maximumFractionDigits,
   };
 
-  return new Intl.NumberFormat(locale, formatOptions).format(amount);
+  try {
+    return new Intl.NumberFormat(locale, formatOptions).format(amount);
+  } catch {
+    // Intl.NumberFormat throws RangeError for non-ISO 4217 currency codes.
+    // Fall back to a plain string so callers don't crash on bad data.
+    const digits = noDecimals ? 0 : (minimumFractionDigits ?? 2);
+    return `${currency} ${amount.toFixed(digits)}`;
+  }
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@price-monitor/worker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/apps/worker/src/services/aiExtractor.ts
+++ b/apps/worker/src/services/aiExtractor.ts
@@ -5,6 +5,7 @@ import { generateObject } from "ai";
 import * as cheerio from "cheerio";
 import { z } from "zod";
 import type { ScraperResult } from "../types/scraper.js";
+import { normalizeCurrency } from "../utils/priceParser.js";
 
 /**
  * Zod schema for structured product data extraction
@@ -259,7 +260,7 @@ export async function aiExtract(_url: string, html: string): Promise<ScraperResu
       data: {
         title: object.title,
         price: priceInCents,
-        currency: object.currency,
+        currency: normalizeCurrency(object.currency),
         imageUrl: object.imageUrl,
       },
       method: "ai",

--- a/apps/worker/src/utils/priceParser.test.ts
+++ b/apps/worker/src/utils/priceParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { CURRENCY_MAP, parsePrice, resolveImageUrl } from "./priceParser";
+import { CURRENCY_MAP, normalizeCurrency, parsePrice, resolveImageUrl } from "./priceParser";
 
 /**
  * priceParser is hit by every successful Tier-1 (HTML) extraction and most
@@ -56,6 +56,35 @@ describe("parsePrice", () => {
   it("exports the documented currency map as a runtime value", () => {
     expect(CURRENCY_MAP.$).toBe("USD");
     expect(CURRENCY_MAP["€"]).toBe("EUR");
+  });
+});
+
+describe("normalizeCurrency", () => {
+  it("returns null for empty / null / whitespace input", () => {
+    expect(normalizeCurrency(null)).toBeNull();
+    expect(normalizeCurrency(undefined)).toBeNull();
+    expect(normalizeCurrency("")).toBeNull();
+    expect(normalizeCurrency("   ")).toBeNull();
+  });
+
+  it("uppercases 3-letter ISO-shaped input", () => {
+    expect(normalizeCurrency("usd")).toBe("USD");
+    expect(normalizeCurrency("NZD")).toBe("NZD");
+    expect(normalizeCurrency(" eur ")).toBe("EUR");
+  });
+
+  it("maps known currency symbols to ISO codes (the reason this exists)", () => {
+    expect(normalizeCurrency("$")).toBe("USD");
+    expect(normalizeCurrency("€")).toBe("EUR");
+    expect(normalizeCurrency("£")).toBe("GBP");
+    expect(normalizeCurrency("A$")).toBe("AUD");
+  });
+
+  it("returns null for anything we can't classify so callers fail loudly", () => {
+    // Critical: we must not guess — saving an unknown string crashes Intl.NumberFormat downstream.
+    expect(normalizeCurrency("dollars")).toBeNull();
+    expect(normalizeCurrency("US$")).toBeNull();
+    expect(normalizeCurrency("USDX")).toBeNull();
   });
 });
 

--- a/apps/worker/src/utils/priceParser.ts
+++ b/apps/worker/src/utils/priceParser.ts
@@ -18,6 +18,27 @@ export const CURRENCY_MAP: Record<string, string> = {
 };
 
 /**
+ * Normalize an arbitrary currency string into a 3-letter ISO 4217 code.
+ *
+ * Returns the uppercased code when the input already looks like ISO (e.g.
+ * "usd" -> "USD"), maps known symbols (e.g. "$" -> "USD") via CURRENCY_MAP,
+ * and returns null for anything we can't confidently classify. We persist
+ * `null` rather than a guess so the price-check job fails loudly instead of
+ * writing data that crashes `Intl.NumberFormat` downstream.
+ */
+export function normalizeCurrency(input: string | null | undefined): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  if (/^[A-Za-z]{3}$/.test(trimmed)) {
+    return trimmed.toUpperCase();
+  }
+
+  return CURRENCY_MAP[trimmed] ?? null;
+}
+
+/**
  * Parse price text into cents and currency
  * @param priceText - Raw price text (e.g., "$19.99", "€1.234,56", "£19.99")
  * @returns Object with price in cents and currency code, or null if parsing fails


### PR DESCRIPTION
- Bump version of @price-monitor/web to 2.0.2 and @price-monitor/worker to 1.1.1.
- Refactor formatPrice function to handle invalid currency codes gracefully, preventing crashes.
- Introduce normalizeCurrency function to map known currency symbols to ISO codes and return null for unrecognized inputs.
- Update unit tests to cover new currency formatting behavior and ensure robustness.